### PR TITLE
Add routes for retracting flags/using the 2.3 version of the SE API for .../flags/options and .../flags/add

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -17,13 +17,13 @@ def lambda_handler(event, context):
     elif event["resource"] == "/auth/confirm":
         return confirm_auth(event)
     elif event["resource"] == "/autoflag":
-        return cast_flags(event)
+        return flags_add_with_api_version("2.2", event)
     elif event["resource"] == "/autoflag/options":
-        return flag_options(event)
-    elif event["resource"] == "/retract":
-        return retract_flags(event)
-    elif event["resource"] == "/retract/options":
-        return retract_options(event)
+        return flags_options_with_api_version("2.2", event)
+    elif event["resource"] == "/retract" or event["resource"] == "/2.3/flags/add":
+        return flags_add_with_api_version("2.3", event)
+    elif event["resource"] == "/retract/options" or event["resource"] == "/2.3/flags/options":
+        return flags_options_with_api_version("2.3", event)
     elif event["resource"] == "/load_tokens":
         return load_tokens(event)
     elif event["resource"] == "/invalidate_tokens":
@@ -94,12 +94,6 @@ def invalidate_tokens(event):
         "body": r.text
     }
 
-def flag_options(event):
-    return flags_options_with_api_version("2.2", event)
-
-def retract_options(event):
-    return flags_options_with_api_version("2.3", event)
-
 def flags_options_with_api_version(api_version, event):
     params = event["queryStringParameters"]
     account_id = params["account_id"]
@@ -135,12 +129,6 @@ def flags_options_with_api_version(api_version, event):
             "headers": {},
             "body": json.dumps({'message': "Invalid post type "+params["post_type"]+". Expected 'question' or 'answer'"})
         }
-
-def cast_flags(event):
-    return flags_add_with_api_version("2.2", event)
-
-def retract_flags(event):
-    return flags_add_with_api_version("2.3", event)
 
 def flags_add_with_api_version(api_version, event):
     params = event["queryStringParameters"]

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -20,6 +20,10 @@ def lambda_handler(event, context):
         return cast_flags(event)
     elif event["resource"] == "/autoflag/options":
         return flag_options(event)
+    elif event["resource"] == "/retract":
+        return retract_flags(event)
+    elif event["resource"] == "/retract/options":
+        return retract_options(event)
     elif event["resource"] == "/load_tokens":
         return load_tokens(event)
     elif event["resource"] == "/invalidate_tokens":
@@ -91,6 +95,12 @@ def invalidate_tokens(event):
     }
 
 def flag_options(event):
+    return flags_options_with_api_version("2.2", event)
+
+def retract_options(event):
+    return flags_options_with_api_version("2.3", event)
+
+def flags_options_with_api_version(api_version, event):
     params = event["queryStringParameters"]
     account_id = params["account_id"]
     api_key = os.environ['API_KEY']
@@ -110,7 +120,7 @@ def flag_options(event):
             'key': api_key,
             'access_token': token
         }
-        uri = "https://api.stackexchange.com/2.2/"+params["post_type"]+"s/"+params["post_id"]+"/flags/options"
+        uri = "https://api.stackexchange.com/"+api_version+"/"+params["post_type"]+"s/"+params["post_id"]+"/flags/options"
         r = requests.get(uri, data=query_string)
         return {
             "isBase64Encoded": False,
@@ -127,6 +137,12 @@ def flag_options(event):
         }
 
 def cast_flags(event):
+    return flags_add_with_api_version("2.2", event)
+
+def retract_flags(event):
+    return flags_add_with_api_version("2.3", event)
+
+def flags_add_with_api_version(api_version, event):
     params = event["queryStringParameters"]
     account_id = params["account_id"]
     api_key = os.environ['API_KEY']
@@ -153,7 +169,7 @@ def cast_flags(event):
             'comment': comment,
             'preview': 'false'
         }
-        uri = "https://api.stackexchange.com/2.2/"+params["post_type"]+"s/"+params["post_id"]+"/flags/add"
+        uri = "https://api.stackexchange.com/"+api_version+"/"+params["post_type"]+"s/"+params["post_id"]+"/flags/add"
         r = requests.post(uri, data=query_string)
         return {
             "isBase64Encoded": False,


### PR DESCRIPTION
From the Lambda's point of view, enabling the retraction of flags is quite simple. The *only* difference from the Lambda's point of view is that for retracting we need to use the 2.3 version of the SE API, rather than the 2.2 version.

However, we don't want to move over to the 2.3 SE API for all operations, because the 2.2 and 2.3 SE API produce substantially different results from a call to `.../flags/options` and then `.../flags/add` with the `option_id` matching the type of flag desired. If we were going to use the 2.3 SE API for the actual autoflagging, we'd need to change the existing logic in MS to handle the responses from the 2.3 SE API which are different from what the 2.2 SE API provides. Given that autoflagging is already working and there really isn't a benefit from moving away from the 2.2 SE API for autoflagging, this PR keeps everything functionally the same for the existing routes and adds the routes:

1. Two identical routes to call the SE API route `.../flags/options` exactly as the `/autoflag/options` route does, just using the 2.3 SE API rather than the 2.2 SE API which the `/autoflag/options` route continues to use. The two aliases for the 2.3 SE API version of this route are:
   * `/retract/options`
   * `/2.3/flags/options`
2. Two identical routes to call the SE API route `.../flags/add` exactly as the `/autoflag` route does, just using the 2.3 SE API rather than the 2.2 SE API which the `/autoflag` route continues to use. The two aliases for the 2.3 SE API version of this route are:
   * `/retract`
   * `/2.3/flags/add`

It's left up to the code which calls these routes to figure out how to handle the data. It should be noted that the `/retract` and `/retract/options` routes could be used to raise flags, but the `/autoflag` and `/autoflag/options` can not be used to perform a retraction.

It's unclear to me if we will at some point in the future want to change the autoflagging code to be compatible with the 2.3 SE API throughout. The `/2.3/flags/options` and `/2.3/flags/add` route aliases are included in case we want to do that in the future, as I felt it would be confusing to have us raising flags by calling a `/retract` route.

#### What would happen if we switched over to using the 2.3 SE API without changing the logic in MS
The primary difference that would be experienced if we cut over to the 2.3 SE API with changing the existing logic is that the first attempt to flag would raise the flag, but if the user attempted to raise another flag on the same post, then the original flag would be retracted, rather than produce the error response which would have happened with the 2.2 SE API. This would end up with a notable number of unexpectedly retracted flags.

The reason for this difference is that requesting the `/2.3/.../flags/options` with a flag already raised on the post will give valid `option_id` values for retracting the flag, whereas the `/2.2/.../flags/options` would have returned `option_id` values which could be used to try to *raise* a flag. When an `option_id` value corresponding to raising a flag is used with `.../flags/add` when a flag is already raised on the post, the SE API produces an error. It is possible to differentiate that the response from the 2.3 SE API has provided retraction options, but that requires additional logic to check a new `is_retraction` property.